### PR TITLE
Attempt to locate device by Vendor & Product ID, should Product name lookup fail

### DIFF
--- a/myusb_utils.c
+++ b/myusb_utils.c
@@ -78,7 +78,7 @@ libusb_device *myusb_get_device_by_prod_name_prefix(const char *prefix, int inde
     return result;
 }
 
-libusb_device *myusb_get_device_by_product_id(const int product_id) {
+libusb_device *myusb_get_device_by_product_id(const int vendor_id, const int product_id) {
 
     libusb_device **devs;
     ssize_t cnt = libusb_get_device_list(NULL, &devs);
@@ -101,7 +101,7 @@ libusb_device *myusb_get_device_by_product_id(const int product_id) {
             continue;
         }
         
-        if (desc.idProduct == product_id)
+        if (desc.idVendor == vendor_id && desc.idProduct == product_id)
         {
             result = devs[i];
         }

--- a/myusb_utils.c
+++ b/myusb_utils.c
@@ -78,6 +78,46 @@ libusb_device *myusb_get_device_by_prod_name_prefix(const char *prefix, int inde
     return result;
 }
 
+libusb_device *myusb_get_device_by_product_id(const int product_id) {
+
+    libusb_device **devs;
+    ssize_t cnt = libusb_get_device_list(NULL, &devs);
+    if (cnt < 0) {
+        fprintf(stderr, "Failed to get device list\n");
+        return NULL;
+    }
+
+    ssize_t i;
+    struct libusb_device_descriptor desc;
+    libusb_device_handle *h;
+    libusb_device *result = NULL;
+    char prodName[MAX_PRODUCT_LEN];
+    int r;
+    for (i = 0; i < cnt && !result; i++) {
+        r = libusb_get_device_descriptor(devs[i], &desc);
+        if (r < 0)
+        {
+            printf("can't get device descriptor, error code %d\n", r);
+            continue;
+        }
+        
+        if (desc.idProduct == product_id)
+        {
+            result = devs[i];
+        }
+    }
+
+    if (result != NULL) {
+        // Increase reference count of device before freeing list.
+        libusb_ref_device(result);
+        my_atexit(myusb_unref_device, result);
+    }
+
+    libusb_free_device_list(devs, 1);
+
+    return result;
+}
+
 const struct libusb_endpoint_descriptor *
 myusb_get_endpoint(libusb_device *dev, uint8_t direction,
              uint8_t attrs_mask, uint8_t attrs, int index,

--- a/myusb_utils.h
+++ b/myusb_utils.h
@@ -27,6 +27,7 @@
 #include <libusb.h>
 
 extern libusb_device *myusb_get_device_by_prod_name_prefix(const char *prefix, int index);
+extern libusb_device *myusb_get_device_by_product_id(const int product_id);
 extern const struct libusb_endpoint_descriptor *
 myusb_get_endpoint(libusb_device *dev, uint8_t direction,
              uint8_t attrs_mask, uint8_t attrs, int index,

--- a/myusb_utils.h
+++ b/myusb_utils.h
@@ -27,7 +27,7 @@
 #include <libusb.h>
 
 extern libusb_device *myusb_get_device_by_prod_name_prefix(const char *prefix, int index);
-extern libusb_device *myusb_get_device_by_product_id(const int product_id);
+extern libusb_device *myusb_get_device_by_product_id(const int vendor_id, const int product_id);
 extern const struct libusb_endpoint_descriptor *
 myusb_get_endpoint(libusb_device *dev, uint8_t direction,
              uint8_t attrs_mask, uint8_t attrs, int index,

--- a/rb3_driver.c
+++ b/rb3_driver.c
@@ -228,6 +228,10 @@ int main(int argc, char **argv) {
 
     libusb_device *dev =
         myusb_get_device_by_prod_name_prefix("Harmonix RB3 Keyboard", device_index);
+    if (dev == NULL) {
+        // Maybe we can locate device by Product ID?
+        dev = myusb_get_device_by_product_id(0x3330);
+    }
 
     if (dev == NULL) {
         fprintf(stderr, "Failed to find input device\n");
@@ -254,7 +258,11 @@ int main(int argc, char **argv) {
     libusb_device_handle *h = NULL;
     r = libusb_open(dev, &h);
     if (r < 0) {
-        fprintf(stderr, "Failed to open input device\n");
+        fprintf(stderr, "Failed to open input device, error code %d\n", r);
+        if (r == -3)
+        {
+            printf("try authorizing access to usb device, or re-running as sudo\n");
+        }
         SLEEP_IF_CHOOSEDEVICE();
         return r;
     }

--- a/rb3_driver.c
+++ b/rb3_driver.c
@@ -230,7 +230,7 @@ int main(int argc, char **argv) {
         myusb_get_device_by_prod_name_prefix("Harmonix RB3 Keyboard", device_index);
     if (dev == NULL) {
         // Maybe we can locate device by Product ID?
-        dev = myusb_get_device_by_product_id(0x3330);
+        dev = myusb_get_device_by_product_id(0x1bad, 0x3330);
     }
 
     if (dev == NULL) {


### PR DESCRIPTION
On my Ubuntu 20.04 system, the Anker USB hub relays no product name for the Wii dongle, whatsoever:

```
% lsusb -v | less
⋮
Bus 003 Device 029: ID 1bad:3330 Harmonix Music USB2.1 Hub
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               1.10
  bDeviceClass            0 
  bDeviceSubClass         0 
  bDeviceProtocol         0 
  bMaxPacketSize0         8
  idVendor           0x1bad Harmonix Music
  idProduct          0x3330 
  bcdDevice            0.05
  iManufacturer           1 
  iProduct                2
```

So the pull request tries to match by Vendor and Product _ID_, should the lookup by product name prove unsuccessful.

It also provides better error feedback, for troubleshooting.