### PR TITLE
Build and run on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 LIBUSB_FLAGS = $(shell pkg-config libusb-1.0 --libs --cflags)
-CCFLAGS += $(LIBUSB_FLAGS)
-LDLIBS += $(LIBUSB_FLAGS) -lportmidi
+LIBPORTMIDI_FLAGS = $(shell pkg-config portmidi --libs --cflags)
+CCFLAGS += $(LIBUSB_FLAGS) $(LIBPORTMIDI_FLAGS)
+LDLIBS += $(LIBUSB_FLAGS) $(LIBPORTMIDI_FLAGS) -lportmidi
 
 all: rb3_driver
 

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,13 @@ UNAME := $(shell uname -s)
 
 LIBUSB_FLAGS = $(shell pkg-config libusb-1.0 --libs --cflags)
 CCFLAGS += $(LIBUSB_FLAGS)
-LDLIBS += $(LIBUSB_FLAGS) -lportmidi
+LDLIBS += $(LIBUSB_FLAGS)
 
 ifeq ($(UNAME),Darwin)
     LIBPORTMIDI_FLAGS = $(shell pkg-config portmidi --libs --cflags)
     CCFLAGS += $(LIBPORTMIDI_FLAGS)
+else
+    LDLIBS += -lportmidi
 endif
 
 all: rb3_driver

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
+UNAME := $(shell uname -s)
+
 LIBUSB_FLAGS = $(shell pkg-config libusb-1.0 --libs --cflags)
-LIBPORTMIDI_FLAGS = $(shell pkg-config portmidi --libs --cflags)
-CCFLAGS += $(LIBUSB_FLAGS) $(LIBPORTMIDI_FLAGS)
-LDLIBS += $(LIBUSB_FLAGS) $(LIBPORTMIDI_FLAGS) -lportmidi
+CCFLAGS += $(LIBUSB_FLAGS)
+LDLIBS += $(LIBUSB_FLAGS) -lportmidi
+
+ifeq ($(UNAME),Darwin)
+    LIBPORTMIDI_FLAGS = $(shell pkg-config portmidi --libs --cflags)
+    CCFLAGS += $(LIBPORTMIDI_FLAGS)
+endif
 
 all: rb3_driver
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To use the driver's output as input to another program, you need some way of
 patching the MIDI "Out" of this program to the MIDI "In" of the other program.
 On Linux, you can use ALSA. On modern Windows, you can use loopMIDI.
 On Windows Vista and earlier, this can be done using [MIDI Yoke](http://www.midiox.com).
+Finally, on macOS you can use Audio MIDI Setup app (in Utilities.)
 
 
 Do I need to install it / is it complicated to use?
@@ -58,8 +59,7 @@ What are the dependencies / how do I compile it?
 
 This fork has been successfully compiled under Linux and Windows (using MSYS2 for 64-bit systems, or MSYS and MinGW32 for 32-bit systems).
 
-The main dependencies are libusb (http://libusb.org/) and PortMidi
-(http://portmedia.sourceforge.net/portmidi/).
+The main dependencies are [libusb](http://libusb.org/) and [PortMidi](http://portmedia.sourceforge.net/portmidi/).
 
 On Linux, you can install them with aptitude:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To use the driver's output as input to another program, you need some way of
 patching the MIDI "Out" of this program to the MIDI "In" of the other program.
 On Linux, you can use ALSA. On modern Windows, you can use loopMIDI.
 On Windows Vista and earlier, this can be done using [MIDI Yoke](http://www.midiox.com).
-Finally, on macOS you can use Audio MIDI Setup app (in Utilities.)
+Finally, on macOS you don't need to install anything else… Core Audio is built-in, and GarageBand can be used for MIDI output (although note that you'll have to pick GarageBand's "Virtual *In*", to connnect.)
 
 
 Do I need to install it / is it complicated to use?

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ On Windows MSYS2, you can install them with pacman. For example, to install them
 pacman -S mingw-w64-clang-x86_64-libusb mingw-w64-clang-x86_64-portmidi
 ```
 
+On macOS and homebrew:
+```zsh
+brew install libusb portmidi
+```
+
 Once you have those in place (and your C compiler/build system obviously!),
 just type "make".
 

--- a/rb3_driver.c
+++ b/rb3_driver.c
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <portmidi.h>
 
-#ifdef _POSIX_SOURCE
+#if defined(_POSIX_SOURCE) || defined(__APPLE__)
     #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Solution inspired by @SgtSalmon's fork of this repo
https://github.com/davidsami/rb3_driver/compare/master...SgtSalmon:rb3_driver:master#diff-3d2678d4f6a4d11783dc251cf6dc33772daf802b240c091b475182a9308aee57L34

The build process on macOS+hombrew produces warnings that reveal we are providing redundant arguments for libusb. I have elected to put that problem off for another day.