### PR TITLE
revise MIDI setup advice (especially for Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,17 @@ interface of your choosing.
 
 To use the driver's output as input to another program, you need some way of
 patching the MIDI "Out" of this program to the MIDI "In" of the other program.
-On Linux, you can use ALSA. On modern Windows, you can use loopMIDI.
-On Windows Vista and earlier, this can be done using [MIDI Yoke](http://www.midiox.com).
-Finally, on macOS you don't need to install anything else… Core Audio is built-in, and GarageBand can be used for MIDI output (although note that you'll have to pick GarageBand's "Virtual *In*", to connnect.)
+
+On Linux, you can use ALSA and some convenient synth (fluidsynth, for example.)
+
+On modern Windows, you can use the native MIDI facility and bundled Microsoft
+GS Wavetable Synth.
+
+On Windows Vista and earlier, you can use [MIDI Yoke](http://www.midiox.com).
+
+Finally, on macOS you don't need to install anything else… Core Audio is
+built-in, and GarageBand can be used for MIDI output (although note that you'll
+have to pick GarageBand's "Virtual *In*", to connnect.)
 
 
 Do I need to install it / is it complicated to use?


### PR DESCRIPTION
I now have rb3_driver working enthusiastically on Linux, Windows and macOS.

I'm still a little unclear as to whether MIDI Yoke was _really_ necessary on ancient Windows versions, but it was in the original README advice, so I've left it.